### PR TITLE
Enable pattern filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ available here https://github.com/criteo/kafka-ganglia
 Install On Broker
 ------------
 
-1. Build the `kafka-graphite-1.0.0.jar` jar using `mvn package`.
-2. Add `kafka-graphite-1.0.0.jar` and `metrics-graphite-2.2.0.jar` to the `libs/` 
+1. Build the `kafka-graphite-1.1.0.jar` jar using `mvn package`.
+2. Add `kafka-graphite-1.1.0.jar` and `metrics-graphite-2.2.0.jar` to the `libs/` 
    directory of your kafka broker installation
 3. Configure the broker (see the configuration section below)
 4. Restart the broker
@@ -33,6 +33,7 @@ Here is a list of default properties used:
     # This can be use to filter some metrics from graphite
     # since kafka has quite a lot of metrics, it is useful
     # if you have many topics/partitions.
+    # Only metrics matching with the pattern will be written to graphite.
     kafka.graphite.metrics.filter.regex="kafka.server":type="BrokerTopicMetrics",.*
 
 Usage As Lib
@@ -40,8 +41,3 @@ Usage As Lib
 
 Simply build the jar and publish it to your maven internal repository (this
 package is not published to any public repositories unfortunately).
-
-This fork
---------
-
-In this fork the filtering option is working. Only the nodes matching with the regex will be exported.

--- a/README.md
+++ b/README.md
@@ -30,13 +30,18 @@ Here is a list of default properties used:
     kafka.graphite.metrics.host=localhost
     kafka.graphite.metrics.port=8649
     kafka.graphite.metrics.group=kafka
-    # This can be use to exclude some metrics from graphite 
+    # This can be use to filter some metrics from graphite
     # since kafka has quite a lot of metrics, it is useful
     # if you have many topics/partitions.
-    kafka.graphite.metrics.exclude.regex=<not set>
+    kafka.graphite.metrics.filter.regex="kafka.server":type="BrokerTopicMetrics",.*
 
 Usage As Lib
 -----------
 
-Simply build the jar and publish it to your maven internal repository (this 
+Simply build the jar and publish it to your maven internal repository (this
 package is not published to any public repositories unfortunately).
+
+This fork
+--------
+
+In this fork the filtering option is working. Only the nodes matching with the regex will be exported.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ available here https://github.com/criteo/kafka-ganglia
 Install On Broker
 ------------
 
-1. Build the `kafka-graphite-1.1.0.jar` jar using `mvn package`.
-2. Add `kafka-graphite-1.1.0.jar` and `metrics-graphite-2.2.0.jar` to the `libs/` 
+1. Build the `kafka-graphite-1.1.6.jar` jar using `mvn package`.
+2. Add `kafka-graphite-1.1.6.jar` and `metrics-graphite-2.2.0.jar` to the `libs/` 
    directory of your kafka broker installation
 3. Configure the broker (see the configuration section below)
 4. Restart the broker

--- a/kafka-graphite.iml
+++ b/kafka-graphite.iml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_6" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Maven: org.apache.kafka:kafka_2.10:0.8.1.1" level="project" />
+    <orderEntry type="library" name="Maven: com.yammer.metrics:metrics-graphite:2.2.0" level="project" />
+    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.2" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.zookeeper:zookeeper:3.3.4" level="project" />
+    <orderEntry type="library" name="Maven: org.scala-lang:scala-library:2.9.2" level="project" />
+    <orderEntry type="library" name="Maven: log4j:log4j:1.2.15" level="project" />
+    <orderEntry type="library" name="Maven: javax.mail:mail:1.4" level="project" />
+    <orderEntry type="library" name="Maven: javax.activation:activation:1.1" level="project" />
+    <orderEntry type="library" name="Maven: net.sf.jopt-simple:jopt-simple:3.2" level="project" />
+    <orderEntry type="library" name="Maven: org.slf4j:slf4j-simple:1.6.4" level="project" />
+    <orderEntry type="library" name="Maven: org.scala-lang:scala-compiler:2.9.2" level="project" />
+    <orderEntry type="library" name="Maven: com.101tec:zkclient:0.3" level="project" />
+    <orderEntry type="library" name="Maven: org.xerial.snappy:snappy-java:1.0.4.1" level="project" />
+    <orderEntry type="library" name="Maven: com.yammer.metrics:metrics-core:2.2.0" level="project" />
+    <orderEntry type="library" name="Maven: com.yammer.metrics:metrics-annotation:2.2.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.easymock:easymock:3.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: cglib:cglib-nodep:2.2" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:1.2" level="project" />
+    <orderEntry type="library" name="Maven: junit:junit:4.11" level="project" />
+    <orderEntry type="library" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.scalatest:scalatest_2.9.2:1.8" level="project" />
+  </component>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.criteo.kafka</groupId>
   <artifactId>kafka-graphite</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <name>Kafka metrics output to Graphite</name>
   <url>http://maven.criteo</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.criteo.kafka</groupId>
   <artifactId>kafka-graphite</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.2</version>
+  <version>1.1.6</version>
   <name>Kafka metrics output to Graphite</name>
   <url>http://maven.criteo</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.criteo.kafka</groupId>
   <artifactId>kafka-graphite</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <name>Kafka metrics output to Graphite</name>
   <url>http://maven.criteo</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.criteo.kafka</groupId>
   <artifactId>kafka-graphite</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <name>Kafka metrics output to Graphite</name>
   <url>http://maven.criteo</url>
 

--- a/src/main/java/com/criteo/kafka/GraphiteReporter.java
+++ b/src/main/java/com/criteo/kafka/GraphiteReporter.java
@@ -35,6 +35,8 @@ public class GraphiteReporter extends AbstractPollingReporter implements MetricP
     protected Writer writer;
     public boolean printVMMetrics = true;
 
+    private boolean hideMetersMeans = false; // Export all data by default
+
     /**
      * Enables the graphite reporter to send data for the default metrics registry to graphite
      * server with the specified period.
@@ -200,6 +202,10 @@ public class GraphiteReporter extends AbstractPollingReporter implements MetricP
         this.predicate = predicate;
     }
 
+    public void setHideMetersMeans(boolean value){
+        this.hideMetersMeans = value;
+    }
+
     @Override
     public void run() {
         Socket socket = null;
@@ -319,10 +325,12 @@ public class GraphiteReporter extends AbstractPollingReporter implements MetricP
     public void processMeter(MetricName name, Metered meter, Long epoch) throws IOException {
         final String sanitizedName = sanitizeName(name);
         sendInt(epoch, sanitizedName, "count", meter.count());
-        sendFloat(epoch, sanitizedName, "meanRate", meter.meanRate());
-        sendFloat(epoch, sanitizedName, "1MinuteRate", meter.oneMinuteRate());
-        sendFloat(epoch, sanitizedName, "5MinuteRate", meter.fiveMinuteRate());
-        sendFloat(epoch, sanitizedName, "15MinuteRate", meter.fifteenMinuteRate());
+        if (!hideMetersMeans) {
+            sendFloat(epoch, sanitizedName, "meanRate", meter.meanRate());
+            sendFloat(epoch, sanitizedName, "1MinuteRate", meter.oneMinuteRate());
+            sendFloat(epoch, sanitizedName, "5MinuteRate", meter.fiveMinuteRate());
+            sendFloat(epoch, sanitizedName, "15MinuteRate", meter.fifteenMinuteRate());
+        }
     }
 
     @Override

--- a/src/main/java/com/criteo/kafka/GraphiteReporter.java
+++ b/src/main/java/com/criteo/kafka/GraphiteReporter.java
@@ -1,0 +1,400 @@
+package com.criteo.kafka;
+
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.*;
+import com.yammer.metrics.reporting.AbstractPollingReporter;
+import com.yammer.metrics.reporting.SocketProvider;
+import com.yammer.metrics.stats.Snapshot;
+import com.yammer.metrics.core.MetricPredicate;
+import org.apache.log4j.Logger;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.lang.Thread.State;
+import java.net.Socket;
+import java.util.Locale;
+import java.util.Map.Entry;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * A simple reporter which sends out application metrics to a <a href="http://graphite.wikidot.com/faq">Graphite</a>
+ * server periodically.
+ */
+public class GraphiteReporter extends AbstractPollingReporter implements MetricProcessor<Long> {
+    private static final Logger LOG = Logger.getLogger(GraphiteReporter.class);
+    protected final String prefix;
+    protected final MetricPredicate predicate;
+    protected final Locale locale = Locale.US;
+    protected final Clock clock;
+    protected final SocketProvider socketProvider;
+    protected final VirtualMachineMetrics vm;
+    protected Writer writer;
+    public boolean printVMMetrics = true;
+
+    /**
+     * Enables the graphite reporter to send data for the default metrics registry to graphite
+     * server with the specified period.
+     *
+     * @param period the period between successive outputs
+     * @param unit   the time unit of {@code period}
+     * @param host   the host name of graphite server (carbon-cache agent)
+     * @param port   the port number on which the graphite server is listening
+     */
+    public static void enable(long period, TimeUnit unit, String host, int port) {
+        enable(Metrics.defaultRegistry(), period, unit, host, port);
+    }
+
+    /**
+     * Enables the graphite reporter to send data for the given metrics registry to graphite server
+     * with the specified period.
+     *
+     * @param metricsRegistry the metrics registry
+     * @param period          the period between successive outputs
+     * @param unit            the time unit of {@code period}
+     * @param host            the host name of graphite server (carbon-cache agent)
+     * @param port            the port number on which the graphite server is listening
+     */
+    public static void enable(MetricsRegistry metricsRegistry, long period, TimeUnit unit, String host, int port) {
+        enable(metricsRegistry, period, unit, host, port, null);
+    }
+
+    /**
+     * Enables the graphite reporter to send data to graphite server with the specified period.
+     *
+     * @param period the period between successive outputs
+     * @param unit   the time unit of {@code period}
+     * @param host   the host name of graphite server (carbon-cache agent)
+     * @param port   the port number on which the graphite server is listening
+     * @param prefix the string which is prepended to all metric names
+     */
+    public static void enable(long period, TimeUnit unit, String host, int port, String prefix) {
+        enable(Metrics.defaultRegistry(), period, unit, host, port, prefix);
+    }
+
+    /**
+     * Enables the graphite reporter to send data to graphite server with the specified period.
+     *
+     * @param metricsRegistry the metrics registry
+     * @param period          the period between successive outputs
+     * @param unit            the time unit of {@code period}
+     * @param host            the host name of graphite server (carbon-cache agent)
+     * @param port            the port number on which the graphite server is listening
+     * @param prefix          the string which is prepended to all metric names
+     */
+    public static void enable(MetricsRegistry metricsRegistry, long period, TimeUnit unit, String host, int port, String prefix) {
+        enable(metricsRegistry, period, unit, host, port, prefix, MetricPredicate.ALL);
+    }
+
+    /**
+     * Enables the graphite reporter to send data to graphite server with the specified period.
+     *
+     * @param metricsRegistry the metrics registry
+     * @param period          the period between successive outputs
+     * @param unit            the time unit of {@code period}
+     * @param host            the host name of graphite server (carbon-cache agent)
+     * @param port            the port number on which the graphite server is listening
+     * @param prefix          the string which is prepended to all metric names
+     * @param predicate       filters metrics to be reported
+     */
+    public static void enable(MetricsRegistry metricsRegistry, long period, TimeUnit unit, String host, int port, String prefix, MetricPredicate predicate) {
+        try {
+            final com.yammer.metrics.reporting.GraphiteReporter reporter = new com.yammer.metrics.reporting.GraphiteReporter(metricsRegistry,
+                    prefix,
+                    predicate,
+                    new DefaultSocketProvider(host,
+                            port),
+                    Clock.defaultClock());
+            reporter.start(period, unit);
+        } catch (Exception e) {
+            LOG.error("Error creating/starting Graphite reporter:", e);
+        }
+    }
+
+    /**
+     * Creates a new {@link com.yammer.metrics.reporting.GraphiteReporter}.
+     *
+     * @param host   is graphite server
+     * @param port   is port on which graphite server is running
+     * @param prefix is prepended to all names reported to graphite
+     * @throws IOException if there is an error connecting to the Graphite server
+     */
+    public GraphiteReporter(String host, int port, String prefix) throws IOException {
+        this(Metrics.defaultRegistry(), host, port, prefix);
+    }
+
+    /**
+     * Creates a new {@link com.yammer.metrics.reporting.GraphiteReporter}.
+     *
+     * @param metricsRegistry the metrics registry
+     * @param host            is graphite server
+     * @param port            is port on which graphite server is running
+     * @param prefix          is prepended to all names reported to graphite
+     * @throws IOException if there is an error connecting to the Graphite server
+     */
+    public GraphiteReporter(MetricsRegistry metricsRegistry, String host, int port, String prefix) throws IOException {
+        this(metricsRegistry,
+                prefix,
+                MetricPredicate.ALL,
+                new DefaultSocketProvider(host, port),
+                Clock.defaultClock());
+    }
+
+    /**
+     * Creates a new {@link com.yammer.metrics.reporting.GraphiteReporter}.
+     *
+     * @param metricsRegistry the metrics registry
+     * @param prefix          is prepended to all names reported to graphite
+     * @param predicate       filters metrics to be reported
+     * @param socketProvider  a {@link SocketProvider} instance
+     * @param clock           a {@link Clock} instance
+     * @throws IOException if there is an error connecting to the Graphite server
+     */
+    public GraphiteReporter(MetricsRegistry metricsRegistry, String prefix, MetricPredicate predicate, SocketProvider socketProvider, Clock clock) throws IOException {
+        this(metricsRegistry, prefix, predicate, socketProvider, clock,
+                VirtualMachineMetrics.getInstance());
+    }
+
+    /**
+     * Creates a new {@link com.yammer.metrics.reporting.GraphiteReporter}.
+     *
+     * @param metricsRegistry the metrics registry
+     * @param prefix          is prepended to all names reported to graphite
+     * @param predicate       filters metrics to be reported
+     * @param socketProvider  a {@link SocketProvider} instance
+     * @param clock           a {@link Clock} instance
+     * @param vm              a {@link VirtualMachineMetrics} instance
+     * @throws IOException if there is an error connecting to the Graphite server
+     */
+    public GraphiteReporter(MetricsRegistry metricsRegistry, String prefix, MetricPredicate predicate, SocketProvider socketProvider, Clock clock, VirtualMachineMetrics vm) throws IOException {
+        this(metricsRegistry, prefix, predicate, socketProvider, clock, vm, "graphite-reporter");
+    }
+
+    /**
+     * Creates a new {@link com.yammer.metrics.reporting.GraphiteReporter}.
+     *
+     * @param metricsRegistry the metrics registry
+     * @param prefix          is prepended to all names reported to graphite
+     * @param predicate       filters metrics to be reported
+     * @param socketProvider  a {@link SocketProvider} instance
+     * @param clock           a {@link Clock} instance
+     * @param vm              a {@link VirtualMachineMetrics} instance
+     * @throws IOException if there is an error connecting to the Graphite server
+     */
+    public GraphiteReporter(MetricsRegistry metricsRegistry, String prefix, MetricPredicate predicate, SocketProvider socketProvider, Clock clock, VirtualMachineMetrics vm, String name) throws IOException {
+        super(metricsRegistry, name);
+        this.socketProvider = socketProvider;
+        this.vm = vm;
+
+        this.clock = clock;
+
+        if (prefix != null) {
+            // Pre-append the "." so that we don't need to make anything conditional later.
+            this.prefix = prefix + ".";
+        } else {
+            this.prefix = "";
+        }
+        this.predicate = predicate;
+    }
+
+    @Override
+    public void run() {
+        Socket socket = null;
+        int counter = 0;
+        try {
+            socket = this.socketProvider.get();
+            writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream()));
+
+            final long epoch = clock.time() / 1000;
+            if (this.printVMMetrics) {
+                printVmMetrics(epoch);
+            }
+            counter = printRegularMetrics(epoch);
+            LOG.info(Integer.toString(counter) + " metrics sent");
+            writer.flush();
+        } catch (Exception e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error writing to Graphite", e);
+            } else {
+                LOG.warn("Error writing to Graphite: ", e);
+            }
+            if (writer != null) {
+                try {
+                    writer.flush();
+                } catch (IOException e1) {
+                    LOG.error("Error while flushing writer:", e1);
+                }
+            }
+        } finally {
+            if (socket != null) {
+                try {
+                    socket.close();
+                } catch (IOException e) {
+                    LOG.error("Error while closing socket:", e);
+                }
+            }
+            writer = null;
+        }
+    }
+
+    protected int printRegularMetrics(final Long epoch) {
+        int counter = 0;
+        for (Entry<String,SortedMap<MetricName,Metric>> entry : getMetricsRegistry().groupedMetrics(
+                predicate).entrySet()) {
+            for (Entry<MetricName, Metric> subEntry : entry.getValue().entrySet()) {
+                final Metric metric = subEntry.getValue();
+                if (metric != null) {
+                    try {
+                        metric.processWith(this, subEntry.getKey(), epoch);
+                        counter++;
+                    } catch (Exception ignored) {
+                        LOG.error("Error printing regular metrics:", ignored);
+                    }
+                }
+            }
+        }
+        return counter;
+    }
+
+    protected void sendInt(long timestamp, String name, String valueName, long value) {
+        sendToGraphite(timestamp, name, valueName + " " + String.format(locale, "%d", value));
+    }
+
+    protected void sendFloat(long timestamp, String name, String valueName, double value) {
+        sendToGraphite(timestamp, name, valueName + " " + String.format(locale, "%2.2f", value));
+    }
+
+    protected void sendObjToGraphite(long timestamp, String name, String valueName, Object value) {
+        sendToGraphite(timestamp, name, valueName + " " + String.format(locale, "%s", value));
+    }
+
+    protected void sendToGraphite(long timestamp, String name, String value) {
+        try {
+            if (!prefix.isEmpty()) {
+                writer.write(prefix);
+            }
+            writer.write(sanitizeString(name));
+            writer.write('.');
+            writer.write(value);
+            writer.write(' ');
+            writer.write(Long.toString(timestamp));
+            writer.write('\n');
+            writer.flush();
+        } catch (IOException e) {
+            LOG.error("Error sending to Graphite:", e);
+        }
+    }
+
+    protected String sanitizeName(MetricName name) {
+        final StringBuilder sb = new StringBuilder()
+                .append(name.getGroup())
+                .append('.')
+                .append(name.getType())
+                .append('.');
+        if (name.hasScope()) {
+            sb.append(name.getScope())
+                    .append('.');
+        }
+        return sb.append(name.getName()).toString();
+    }
+
+    protected String sanitizeString(String s) {
+        return s.replace(' ', '-');
+    }
+
+    @Override
+    public void processGauge(MetricName name, Gauge<?> gauge, Long epoch) throws IOException {
+        sendObjToGraphite(epoch, sanitizeName(name), "value", gauge.value());
+    }
+
+    @Override
+    public void processCounter(MetricName name, Counter counter, Long epoch) throws IOException {
+        sendInt(epoch, sanitizeName(name), "count", counter.count());
+    }
+
+    @Override
+    public void processMeter(MetricName name, Metered meter, Long epoch) throws IOException {
+        final String sanitizedName = sanitizeName(name);
+        sendInt(epoch, sanitizedName, "count", meter.count());
+        sendFloat(epoch, sanitizedName, "meanRate", meter.meanRate());
+        sendFloat(epoch, sanitizedName, "1MinuteRate", meter.oneMinuteRate());
+        sendFloat(epoch, sanitizedName, "5MinuteRate", meter.fiveMinuteRate());
+        sendFloat(epoch, sanitizedName, "15MinuteRate", meter.fifteenMinuteRate());
+    }
+
+    @Override
+    public void processHistogram(MetricName name, Histogram histogram, Long epoch) throws IOException {
+        final String sanitizedName = sanitizeName(name);
+        sendSummarizable(epoch, sanitizedName, histogram);
+        sendSampling(epoch, sanitizedName, histogram);
+    }
+
+    @Override
+    public void processTimer(MetricName name, Timer timer, Long epoch) throws IOException {
+        processMeter(name, timer, epoch);
+        final String sanitizedName = sanitizeName(name);
+        sendSummarizable(epoch, sanitizedName, timer);
+        sendSampling(epoch, sanitizedName, timer);
+    }
+
+    protected void sendSummarizable(long epoch, String sanitizedName, Summarizable metric) throws IOException {
+        sendFloat(epoch, sanitizedName, "min", metric.min());
+        sendFloat(epoch, sanitizedName, "max", metric.max());
+        sendFloat(epoch, sanitizedName, "mean", metric.mean());
+        sendFloat(epoch, sanitizedName, "stddev", metric.stdDev());
+    }
+
+    protected void sendSampling(long epoch, String sanitizedName, Sampling metric) throws IOException {
+        final Snapshot snapshot = metric.getSnapshot();
+        sendFloat(epoch, sanitizedName, "median", snapshot.getMedian());
+        sendFloat(epoch, sanitizedName, "75percentile", snapshot.get75thPercentile());
+        sendFloat(epoch, sanitizedName, "95percentile", snapshot.get95thPercentile());
+        sendFloat(epoch, sanitizedName, "98percentile", snapshot.get98thPercentile());
+        sendFloat(epoch, sanitizedName, "99percentile", snapshot.get99thPercentile());
+        sendFloat(epoch, sanitizedName, "999percentile", snapshot.get999thPercentile());
+    }
+
+    protected void printVmMetrics(long epoch) {
+        sendFloat(epoch, "jvm.memory", "heap_usage", vm.heapUsage());
+        sendFloat(epoch, "jvm.memory", "non_heap_usage", vm.nonHeapUsage());
+        for (Entry<String, Double> pool : vm.memoryPoolUsage().entrySet()) {
+            sendFloat(epoch, "jvm.memory.memory_pool_usages", sanitizeString(pool.getKey()), pool.getValue());
+        }
+
+        sendInt(epoch, "jvm", "daemon_thread_count", vm.daemonThreadCount());
+        sendInt(epoch, "jvm", "thread_count", vm.threadCount());
+        sendInt(epoch, "jvm", "uptime", vm.uptime());
+        sendFloat(epoch, "jvm", "fd_usage", vm.fileDescriptorUsage());
+
+        for (Entry<State, Double> entry : vm.threadStatePercentages().entrySet()) {
+            sendFloat(epoch, "jvm.thread-states", entry.getKey().toString().toLowerCase(), entry.getValue());
+        }
+
+        for (Entry<String, VirtualMachineMetrics.GarbageCollectorStats> entry : vm.garbageCollectors().entrySet()) {
+            final String name = "jvm.gc." + sanitizeString(entry.getKey());
+            sendInt(epoch, name, "time", entry.getValue().getTime(TimeUnit.MILLISECONDS));
+            sendInt(epoch, name, "runs", entry.getValue().getRuns());
+        }
+    }
+
+    public static class DefaultSocketProvider implements SocketProvider {
+
+        private final String host;
+        private final int port;
+
+        public DefaultSocketProvider(String host, int port) {
+            this.host = host;
+            this.port = port;
+
+        }
+
+        @Override
+        public Socket get() throws Exception {
+            return new Socket(this.host, this.port);
+        }
+
+    }
+}

--- a/src/main/java/com/criteo/kafka/KafkaGraphiteMetricsReporter.java
+++ b/src/main/java/com/criteo/kafka/KafkaGraphiteMetricsReporter.java
@@ -44,7 +44,6 @@ public class KafkaGraphiteMetricsReporter implements KafkaMetricsReporter,
 			reporter.start(pollingPeriodSecs, TimeUnit.SECONDS);
 			running = true;
 			LOG.info(String.format("Started Kafka Graphite metrics reporter with polling period %d seconds", pollingPeriodSecs));
-			//System.out.println(String.format("Started Kafka Graphite metrics reporter with polling period %d seconds", pollingPeriodSecs));
 		}
 	}
 
@@ -77,7 +76,6 @@ public class KafkaGraphiteMetricsReporter implements KafkaMetricsReporter,
             String regex = props.getString("kafka.graphite.metrics.filter.regex", null);
 
             LOG.debug("Initialize GraphiteReporter ["+graphiteHost+","+graphitePort+","+graphiteGroupPrefix+"]");
-            //System.out.println("Initialize GraphiteReporter ["+graphiteHost+","+graphitePort+","+graphiteGroupPrefix+"]");
 
             if (regex != null)
             	predicate = new RegexMetricPredicate(regex);

--- a/src/main/java/com/criteo/kafka/RegexMetricPredicate.java
+++ b/src/main/java/com/criteo/kafka/RegexMetricPredicate.java
@@ -19,8 +19,8 @@ public class RegexMetricPredicate implements MetricPredicate {
 	
 	@Override
 	public boolean matches(MetricName name, Metric metric) {
-		boolean ok = !pattern.matcher(name.getName()).matches();
-		//LOG.info(String.format("name: %s - %s", name.getName(), ok));
+		boolean ok = pattern.matcher(name.getMBeanName()).matches();
+		//LOG(String.format("name: %s - %s", name.getMBeanName(), ok));
 		return ok;
 	}
 


### PR DESCRIPTION
The pattern filtering was not enabled. In this version is now possible to specify a pattern of metrics to be exported to graphite. Please notice that the pattern specify which metrics we want to include.

A future release may include a list of patterns.