### PR TITLE
Updating default registry for support of Kafka 2.6 and above

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.criteo.kafka</groupId>
   <artifactId>kafka-graphite</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <name>Kafka metrics output to Graphite</name>
   <url>https://github.com/emetriq/kafka-graphite/</url>
 
@@ -18,8 +18,8 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka_2.10</artifactId>
-      <version>0.8.2.1</version>
+      <artifactId>kafka_2.13</artifactId>
+      <version>2.6.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/criteo/kafka/KafkaGraphiteMetricsReporter.java
+++ b/src/main/java/com/criteo/kafka/KafkaGraphiteMetricsReporter.java
@@ -18,19 +18,19 @@
 
 package com.criteo.kafka;
 
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import com.yammer.metrics.core.Clock;
+import com.yammer.metrics.core.MetricPredicate;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.yammer.metrics.Metrics;
-import com.yammer.metrics.core.Clock;
-import com.yammer.metrics.core.MetricPredicate;
+import java.io.IOException;
 import java.util.EnumSet;
+import java.util.concurrent.TimeUnit;
 
 import kafka.metrics.KafkaMetricsConfig;
 import kafka.metrics.KafkaMetricsReporter;
+import kafka.metrics.KafkaYammerMetrics;
 import kafka.utils.VerifiableProperties;
 
 public class KafkaGraphiteMetricsReporter implements KafkaMetricsReporter, KafkaGraphiteMetricsReporterMBean {
@@ -100,12 +100,12 @@ public class KafkaGraphiteMetricsReporter implements KafkaMetricsReporter, Kafka
         }
     }
 
-
+    //Metrics was deprecated in 2.6 and it was replaced with KafkaYammerMetrics
     private FilteredGraphiteReporter buildGraphiteReporter() {
         FilteredGraphiteReporter graphiteReporter = null;
         try {
             graphiteReporter = new FilteredGraphiteReporter(
-                    Metrics.defaultRegistry(),
+                    KafkaYammerMetrics.defaultRegistry(),
                     metricPrefix,
                     metricPredicate,
                     metricDimensions,


### PR DESCRIPTION
In Kafka 2.6 the Metrics.defaultRegistry() was deprecated and replaced
with KafkaYammerMetrics.defaultRegistry() as per KIP-544.

Author: Kashish Sharma, Mudassir Razvi
Company: Zapr Media Labs

Note: For future changes reach out to devops@zapr.in.